### PR TITLE
最新mainブランチの反映

### DIFF
--- a/app/Http/Controllers/Admin/Actions/Event/CreateAction.php
+++ b/app/Http/Controllers/Admin/Actions/Event/CreateAction.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Admin\Actions\Event;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
 class CreateAction
@@ -13,15 +12,8 @@ class CreateAction
     {
         $adminUser = Auth::user();
 
-        // すでにイベントが付与されている商品IDを取得
-        $productsWithEvents = DB::table('event_product')
-            ->pluck('product_id')
-            ->unique()
-            ->toArray();
-
-        // 管理者の商品から、すでにイベントが付与されている商品を除外
+        // 管理者の全ての商品を取得
         $products = $adminUser->products()
-            ->whereNotIn('products.id', $productsWithEvents)
             ->pluck('name', 'id');
 
         return view('admin.event.create')

--- a/app/Http/Controllers/Admin/Actions/Event/EditAction.php
+++ b/app/Http/Controllers/Admin/Actions/Event/EditAction.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Admin\Actions\Event;
 use App\Models\Event;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
 class EditAction
@@ -22,22 +21,8 @@ class EditAction
         // 関連データをロード
         $event->load(['products', 'image']);
 
-        // 他のイベント（現在編集中のイベント以外）に紐づいている商品IDを取得
-        $productsWithOtherEvents = DB::table('event_product')
-            ->where('event_id', '!=', $event->id)
-            ->pluck('product_id')
-            ->unique()
-            ->toArray();
-
-        // 現在のイベントに紐づいている商品ID
-        $currentEventProductIds = $event->products->pluck('id')->toArray();
-
-        // 除外すべき商品ID = 他のイベントに紐づいている商品ID - 現在のイベントに紐づいている商品ID
-        $excludeProductIds = array_diff($productsWithOtherEvents, $currentEventProductIds);
-
-        // 管理者の商品から、他のイベントに紐づいている商品を除外
+        // 管理者の全ての商品を取得
         $products = $adminUser->products()
-            ->whereNotIn('products.id', $excludeProductIds)
             ->pluck('name', 'id');
 
         return view('admin.event.edit')


### PR DESCRIPTION
**概要**
イベントの取得方法について、複数のイベントの付与ができるように調整を実施

**詳細**
既存仕様...特定の商品に紐づけるイベントの情報は一件まで
新規仕様...特定の商品に対して複数のイベントを紐づける事が可能である


