### PR TITLE
イベント画像テーブルの一時退避

### DIFF
--- a/database/migrations/2025_10_05_092310_create_event_images_table.php
+++ b/database/migrations/2025_10_05_092310_create_event_images_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('event_image', function (Blueprint $table) {
+        Schema::create('event_images', function (Blueprint $table) {
             $table->id();
             $table->foreignId('event_id')->constrained('events')->onDelete('cascade')->comment('イベントID');
             $table->string('original_filename')->comment('ファイル名');


### PR DESCRIPTION
**概要**
イベントのインサート時に、Laravel側で認知されているテーブル名とDB内で作成されているテーブル名の違いによってエラーが発生

**詳細**
2025_10_05_092310_create_event_images_tableファイルのコード中のテーブル名を適切な形(複数形)に変更を行い修正を実施